### PR TITLE
Fix in url parser after go 1.12.8

### DIFF
--- a/common.go
+++ b/common.go
@@ -17,15 +17,19 @@ import (
 type Logger = log.Logger
 
 const (
-	MYSQL_DRIVER    = "mysql"
-	SQLITE_DRIVER   = "sqlite3"
-	POSTGRES_DRIVER = "postgres"
+	// DriverMySQL represents the database driver name of MySQL
+	DriverMySQL = "mysql"
+	// DriverSQLite represents the database driver name of SQLite3
+	DriverSQLite = "sqlite3"
+	// DriverPostgres represents the databse driver name of Postgres
+	DriverPostgres = "postgres"
 )
 
+// Error codes returned by failures to parse a dsn.
 var (
-	errNoDriverName = errors.New("No driver name")
-	errEmptyConnURL = errors.New("URL cannot be empty")
-	errInvalidDSN   = errors.New("Invalid DSN")
+	errNoDriverName = errors.New("no driver name")
+	errEmptyConnURL = errors.New("url cannot be empty")
+	errInvalidDSN   = errors.New("invalid dsn")
 )
 
 // ParseURL parses a URL and returns the database driver and connection string to the database
@@ -36,15 +40,15 @@ func ParseURL(conn string) (string, string, error) {
 	}
 
 	switch driver {
-	case MYSQL_DRIVER:
+	case DriverMySQL:
 		mysqlSource, err := parseMySQL(driver, source)
 		if err != nil {
 			return "", "", err
 		}
 		return driver, mysqlSource, nil
-	case SQLITE_DRIVER:
+	case DriverSQLite:
 		return driver, source, nil
-	case POSTGRES_DRIVER:
+	case DriverPostgres:
 		return driver, conn, nil
 	default:
 		return driver, conn, nil

--- a/common_test.go
+++ b/common_test.go
@@ -22,6 +22,13 @@ var _ = Describe("ParseURL", func() {
 			Expect(source).To(Equal("root@tcp(127.0.0.1:3306)/prana?parseTime=true"))
 		})
 
+		It("parses the MySQL connection string with custom port successfully", func() {
+			driver, source, err := prana.ParseURL("mysql://root:password@tcp(127.0.0.1:13306)/prana")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(driver).To(Equal("mysql"))
+			Expect(source).To(Equal("root:password@tcp(127.0.0.1:13306)/prana?parseTime=true"))
+		})
+
 		Context("when the DSN is invalid", func() {
 			It("returns the error", func() {
 				driver, source, err := prana.ParseURL("mysql://@net(addr/")
@@ -39,12 +46,21 @@ var _ = Describe("ParseURL", func() {
 		Expect(source).To(Equal("postgres://localhost/prana?sslmode=disable"))
 	})
 
+	Context("when the URL is empty", func() {
+		It("returns an error", func() {
+			driver, source, err := prana.ParseURL("")
+			Expect(driver).To(BeEmpty())
+			Expect(source).To(BeEmpty())
+			Expect(err).To(MatchError("URL cannot be empty"))
+		})
+	})
+
 	Context("when the URL is invalid", func() {
 		It("returns an error", func() {
 			driver, source, err := prana.ParseURL("::")
 			Expect(driver).To(BeEmpty())
 			Expect(source).To(BeEmpty())
-			Expect(err).To(MatchError("parse ::: missing protocol scheme"))
+			Expect(err).To(MatchError("Invalid DSN"))
 		})
 	})
 })

--- a/common_test.go
+++ b/common_test.go
@@ -51,7 +51,7 @@ var _ = Describe("ParseURL", func() {
 			driver, source, err := prana.ParseURL("")
 			Expect(driver).To(BeEmpty())
 			Expect(source).To(BeEmpty())
-			Expect(err).To(MatchError("URL cannot be empty"))
+			Expect(err).To(MatchError("url cannot be empty"))
 		})
 	})
 
@@ -60,7 +60,7 @@ var _ = Describe("ParseURL", func() {
 			driver, source, err := prana.ParseURL("::")
 			Expect(driver).To(BeEmpty())
 			Expect(source).To(BeEmpty())
-			Expect(err).To(MatchError("Invalid DSN"))
+			Expect(err).To(MatchError("invalid dsn"))
 		})
 	})
 })


### PR DESCRIPTION
### Description

Fix net/url.Parse no longer works for dsn string with port after go 1.12.8

```
parse mysql://user@tcp(localhost:3306)/boulder_test?parseTime=true: invalid port ":3306)" after host
```

Releated issue: https://github.com/golang/go/issues/33646

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README.md / documentation, if necessary
- [ ] Added myself / the copyright holder to the CONTRIBUTORS file
